### PR TITLE
Remove unused nexus staging plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ plugins {
     id 'nebula.release' version '15.2.0'
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.8.2'
-    id 'io.codearte.nexus-staging' version '0.22.0'
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 


### PR DESCRIPTION
## Description

Remove the now unused nexus staging plugin since we use 'io.github.gradle-nexus.publish-plugin'