### PR TITLE
Add snyk monitoring [ATLAS-675]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
 #!groovy
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-withCredentials([string(credentialsId: 'spock_uvm_extension_coveralls_token', variable: 'coveralls_token')]) {
-    buildJavaLibraryOSSRH coverallsToken: coveralls_token, testEnvironment: []
+withCredentials([string(credentialsId: 'snyk-wdk-token', variable: 'SNYK_TOKEN')]) {
+    withEnv(['SNYK_ORG_NAME=wooga-pipeline', 'SNYK_AUTO_DOWNLOAD=YES']) {
+        buildJavaLibraryOSSRH platforms: ['macos', 'linux']
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,10 @@ plugins {
     id 'signing'
     id 'nebula.release' version '15.3.1'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.12.0'
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-wdk-java" version "0.3.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
 group "com.wooga.spock.extensions"
@@ -36,10 +38,10 @@ if (cliTasks.contains("rc")) {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:(2.4,2.5]'
-    implementation 'org.spockframework:spock-core:1.2-groovy-2.4'
+    implementation 'org.codehaus.groovy:groovy-all:2.5.16'
+    implementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     implementation 'net.wooga:unity-version-manager-jni:[1,2)'
-    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
+    testImplementation 'com.github.stefanbirkner:system-rules:[1.19,2)'
 }
 
 repositories {


### PR DESCRIPTION
## Description

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin `net.wooga.cve-dependency-resolution` which applies overrides for dependencies with know fixes for security issues.

Along with the introduction of snyk I also upgraded/removed some depdencies. Coveralls produces a huge load of errors even with the latest version so I decided to remove it since we want/are moving to sonarqube (It is unknown at this time if this dependency is actually better or not).

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin
* ![REMOVE] coveralls plugin (even though it was unused here)
* ![UPDATE] `org.codehaus.groovy:groovy-all` to version `2.5.16`
* ![UPDATE] `com.github.stefanbirkner:system-rules` to version `[1.19,2)`
* ![UPDATE] `org.spockframework:spock-core` to version `1.3-groovy-2.5`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"



